### PR TITLE
Fix images in documentation

### DIFF
--- a/docs/communication-preferences.md
+++ b/docs/communication-preferences.md
@@ -33,7 +33,7 @@ In order to configure the communication preferences settings carry out the follo
 
 Once clicked, you'll be presented with the communications preferences configuration page.
 
-![Communication Preferences Main](/images/communication-preferences-main.png)
+![Communication Preferences Main](images/communication-preferences-main.png)
 
 * **Page title** The page title and form title to be displayed when a supporter visits the communication preferences page
 * **Introduction** Text to be displayed at the top of the communication preferences page
@@ -41,17 +41,17 @@ Once clicked, you'll be presented with the communications preferences configurat
 
 For example, the following settings
 
-![Communication Preferences Main](/images/communication-preferences-main-example.png)
+![Communication Preferences Main](images/communication-preferences-main-example.png)
 
 Would result in the Communications Preferences page displaying as follows
 
-![Supporter Communication Preferences](/images/communication-preferences-page-example-1.png)
+![Supporter Communication Preferences](images/communication-preferences-page-example-1.png)
 
 ### Communicatin Channels
 
 Supporters also need the ability to confirm which channels they are happy to be communicated via i.e. a support may chose to indicate they never wish to be contacted via phone or via email. The communication preferences configuration allows you to control which options are available to supporters.
 
-![Supporter Communication Preferences](/images/communication-preferences-page-channels.png)
+![Supporter Communication Preferences](images/communication-preferences-page-channels.png)
 
 * **Enable Channels** Controls whether channels should be avilable for selection by supporters
 * **Introduction** Text to be displayed at the top of the channels section
@@ -59,7 +59,7 @@ Supporters also need the ability to confirm which channels they are happy to be 
 
 On enabling the channels the communication preferences page will reflect the options made available, as can be seen in the "Please tell us how you would like us to keep in touch." Section.
 
-![Supporter Communication Preferences](/images/communication-preferences-page-example-2.png)
+![Supporter Communication Preferences](images/communication-preferences-page-example-2.png)
 
 !!! note
     The channels chosen by a supporter will influence they groups they can opt into. For example if a supporter decides they do not wish to be emailed then a group which is email only will not be available for the supporter to opt into.
@@ -70,19 +70,19 @@ Under the GDPR regulations its imperative that supporters can easily and without
 
 On enabling the **Allow users to opt-in to mailing groups.** checkbox, all groups that are set to be **Publicly Accessible** will be listed.
 
-![Supporter Communication Preferences](/images/communication-preferences-groups.png)
+![Supporter Communication Preferences](images/communication-preferences-groups.png)
 
 !!! note
     The **Email** channel is a reflection of the no bulk emails setting in CiviCRM. Therefore if a supporter opts out of email their **No Bulk Emails** communication preference will be activated. The reason for this approach is that transactional emails, such as event registration confirmation or donation receipts, will still be sent, it is only mass communications that the supporter is opting out of.
 
-To check whether your groups are Publicly Accessible: 
+To check whether your groups are Publicly Accessible:
 
 * Navigate to: Contacts > Manage Groups
 * Search for your mailing group
 * Click the settings for that group
 * Change the **Visibility** to Public Pages and save
 
-![Groups Public Pages](/images/public.png)
+![Groups Public Pages](images/public.png)
 
 Search Each group has the following options
 
@@ -94,20 +94,20 @@ Search Each group has the following options
 
 !!! note
     Part of the GDPR regulation includes ensuring supporters are clear about the groups they are opting into. Its therefore advisable to include the type of information, the frequency and format of the communications that will be sent as a result of the supporter opting into the group.
-    
+
 Using the options we're able to produce a communications preferences page as below
 
-![Supporter Communication Preferences](/images/communication-preferences-page-example-3.png)
+![Supporter Communication Preferences](images/communication-preferences-page-example-3.png)
 
 An example of the warning displayed to a supporter if they opt out of a communication channel needed by a group they are opting into can be seen below
 
-![Supporter Communication Preferences](/images/communication-preferences-page-example-4.png)
+![Supporter Communication Preferences](images/communication-preferences-page-example-4.png)
 
 ### Thank You Page
 
 The completion section of the configuration allows the organisation to control the journey on submmission of the communication preferences by a supporter.
 
-![Supporter Communication Preferences](/images/communication-preferences-completion.png)
+![Supporter Communication Preferences](images/communication-preferences-completion.png)
 
 * **On Completion** Use this setting to either direct the suppoerter to a custom page or present the pre configured message
 * **Completion message** Message to be displayed if a redirect is not in place
@@ -118,32 +118,32 @@ On submission of the page, activities and updates to the GDPR tab will be reflec
 
 Firstly any channels the supporter opts out of will be reflected in the communication preferences, for example opting out of phone would be reflected as follows
 
-![Supporter Communication Preferences](/images/communication-preferences-do-not-phone.png)
+![Supporter Communication Preferences](images/communication-preferences-do-not-phone.png)
 
 An activity will be generated each time the communication preferences are updated by a supporter, including an activity to reflect the acceptance of the data policy
 
-![Supporter Communication Preferences](/images/communication-preferences-activities.png)
+![Supporter Communication Preferences](images/communication-preferences-activities.png)
 
 The groups tab will be updated to reflect communications the supporter has opted into.
 
-![Supporter Communication Preferences](/images/communication-preferences-contact-groups.png)
+![Supporter Communication Preferences](images/communication-preferences-contact-groups.png)
 
 Finally the GDPR tab against the supporter will also reflect all the changes, including the last submission dates.
 
-![Supporter Communication Preferences](/images/communication-preferences-gdpr-tab.png)
+![Supporter Communication Preferences](images/communication-preferences-gdpr-tab.png)
 
 ### Tokens
 
 Four new tokens have been introduced, to allow you to request updates from supporters. The tokens will automatically add the checksum to the links supporters receive, so that they do not need to login in order to update their communication preferences. We would expect most users of the GDPR extension to replace the traditional opt out and unsubscribe links with this single communication preferences page.
 
-![Supporter Communication Preferences](/images/communication-preferences-tokens.png)
+![Supporter Communication Preferences](images/communication-preferences-tokens.png)
 
-* **Communicaion Preferences Link** This token creates a clickable link the in template, with the description takens from the settings, including the checksum of the contact being communicated with. 
+* **Communicaion Preferences Link** This token creates a clickable link the in template, with the description takens from the settings, including the checksum of the contact being communicated with.
 * **Communicaion Preferences URL** This token creates a plain URL template including the checksum of the contact being communicated with. For example this token could then be used for clickable images within outbound communications.
 
-![Supporter Communication Preferences Bulk Mailing](/images/bulkcommspref.png)
+![Supporter Communication Preferences Bulk Mailing](images/bulkcommspref.png)
 
-* **Communicaion Preferences Link (Bulk Mailing)** This token creates a clickable link the in a Bulk Mailing template, with the description takens from the settings, including the checksum of the contact being communicated with. 
+* **Communicaion Preferences Link (Bulk Mailing)** This token creates a clickable link the in a Bulk Mailing template, with the description takens from the settings, including the checksum of the contact being communicated with.
 * **Communicaion Preferences URL (Bulk Mailing)** This token creates a plain URL template including the checksum of the contact being communicated with. For example this token could then be used for clickable images within outbound communications.
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,23 +5,23 @@
 Use the following steps to configure GDPR.
 
 1. Navigatge to the Contacts menu > GDPR Dashboard > GDPR Settings
-![GDPR Dashboard screenshot](/images/contactmenu.png)
-![GDPR Dashboard screenshot](/images/gdpr-dashboard.png)
-2. Data Protection Officer 
+![GDPR Dashboard screenshot](images/contactmenu.png)
+![GDPR Dashboard screenshot](images/gdpr-dashboard.png)
+2. Data Protection Officer
 Select your Data Protection Officer from your contact database, or add a new contact if they don't already exist.
-![Data Protection Officer screenshot](/images/data-protection-officer.png)
+![Data Protection Officer screenshot](images/data-protection-officer.png)
 3. Activity Types
 Set the activity types you want to check where contacts that have not had any activity for a set period of time. For example you may want to look for all contacts that haven’t been sent a bulk email, paid a contribution or registered for an event in the last 100 days.
-![Activity Types screenshot](/images/activity-types.png)
+![Activity Types screenshot](images/activity-types.png)
 4. Forget me
 This is where you can choose the title you want to give contacts that have been made anonymous. Some examples to use might be, Anon, Anonymous, Forgotton
-![Forget me screenshot](/images/forget-me.png)
+![Forget me screenshot](images/forget-me.png)
 5. Data policy
 This is where you can upload your Data Policy. These settings relate to sitewise agreements such as Data Policy or Terms and Conditions. These settings will apply in the Communications Preferences page and when Terms and Conditions are used with Events.
-![Data policy screenshot](/images/data-policy.png)
+![Data policy screenshot](images/data-policy.png)
 6. Terms & Conditions: Events and Contribution Pages
 This is where you can upload your Terms & Conditions. You can set default files for your Terms & Conditions. You can override these in the settings for individual Events and Contribution Pages.
-![Terms & Conditions: Events and Contribution Pages screenshot](/images/tc.png)
+![Terms & Conditions: Events and Contribution Pages screenshot](images/tc.png)
 
 
 

--- a/docs/data-policy.md
+++ b/docs/data-policy.md
@@ -10,7 +10,7 @@ In order to record the acceptance of the data policy, including a copy of the po
 
 Under the general settings within the GDPR extension there is a section dedicated to your organisations **Data Policy**
 
-![Data Policy Settings](/images/data-policy-settings.png)
+![Data Policy Settings](images/data-policy-settings.png)
 
 * **Acceptance period (months)** The period of time that the system will allow before a reconfirmation is requested from the supporter.
 * **Data Policy file** The Data Policy statement for your organisation. A version history is kept if updated versions of the document are uploaded.
@@ -21,7 +21,7 @@ Under the general settings within the GDPR extension there is a section dedicate
 
 An example of the settings can be seen on the communication preference page, as below
 
-![Data Policy Settings](/images/data-policy-example.png)
+![Data Policy Settings](images/data-policy-example.png)
 
 On submission an Activity is recorded against the supporter with a link to a copy of the data policy at the time of acceptance.
 

--- a/docs/events-terms-and-conditions.md
+++ b/docs/events-terms-and-conditions.md
@@ -1,13 +1,13 @@
 # Events terms & conditions configuration
 
 - Navigate to Manage Events pages and select your event
-![GDPR Manage Event screenshot](/images/manageevents.png)
+![GDPR Manage Event screenshot](images/manageevents.png)
 - Go to the Configuration settings for your event
-![GDPR Event Config screenshot](/images/configevents.png)
+![GDPR Event Config screenshot](images/configevents.png)
 - Under the event configuration, there is now a Terms & conditions tab
-![GDPR Event t&C screenshot](/images/eventt&C.png)
-- Complete the settings for where you want the t&c's checkbox located and complete the title you wouldlike to appear with a description if any 
+![GDPR Event t&C screenshot](images/eventt&C.png)
+- Complete the settings for where you want the t&c's checkbox located and complete the title you wouldlike to appear with a description if any
 - Under the Event Links button, navigate to hte Online Registration page to view the settings
-![GDPR Event live link](/images/eventlivelink.png)
+![GDPR Event live link](images/eventlivelink.png)
 - The online live contribution page now displays the event terms & conditions
 ![GDPR Event Page screenshot](images/eventslivepage.png)

--- a/docs/identifying-inactive-contacts.md
+++ b/docs/identifying-inactive-contacts.md
@@ -8,18 +8,18 @@ Part of the GDPR extension introduces a custom search, which identifies supporte
 
 These settings can be controlled within the GDPR setup
 
-![Communication Preferences Main](/images/inactive-settings.png)
+![Communication Preferences Main](images/inactive-settings.png)
 
-* **Contact Types** - The contact types that should be included in the search, for example it may not be necessary to identify organisations without activity. 
-* **Activity Types** - A list of the activities that the organisation deems to be engagement and therefore exclude any contacts who have had the activity recorded on their record. 
+* **Contact Types** - The contact types that should be included in the search, for example it may not be necessary to identify organisations without activity.
+* **Activity Types** - A list of the activities that the organisation deems to be engagement and therefore exclude any contacts who have had the activity recorded on their record.
 * **Period** - Period of time to check i.e. setting of 500 would expect the custom search to check anyone who has not had any of the above activities within the last 500 days. In this way we can search back any number of years, identifying the most toxic data first before moving to more recent contacts.
 
 ## Actions
 
 The GDPR dashboard will show the contacts who meet the criteria that have been configured.
 
-![Communication Preferences Main](/images/inactive-dashboard.png)
+![Communication Preferences Main](images/inactive-dashboard.png)
 
 Clicking on the number will then present the contacts who have been identified, from the results you can perform an action, for example add to a group for a final communication or delete the contacts if they are invalid.
 
-![Communication Preferences Main](/images/inactive-actions.png)
+![Communication Preferences Main](images/inactive-actions.png)

--- a/docs/membership-terms-and-conditions.md
+++ b/docs/membership-terms-and-conditions.md
@@ -1,6 +1,6 @@
 # Membership Terms & Conditions
 
-Under GDPR, there are specific terms which must be included in contracts which govern data processing. 
+Under GDPR, there are specific terms which must be included in contracts which govern data processing.
 
 Data controllers must ensure that contracts set out:
 
@@ -12,13 +12,13 @@ Data controllers must ensure that contracts set out:
 # Membership terms & conditions configuration
 
 - Navigate to Manage Contribution pages and select your membership contribution page
-![GDPR Manage Contribution screenshot](/images/managecontribution.png)
+![GDPR Manage Contribution screenshot](images/managecontribution.png)
 - Go to the Configuration settings for your contribution page
-![GDPR Membership Config screenshot](/images/membershipconfig.png)
+![GDPR Membership Config screenshot](images/membershipconfig.png)
 - Under the contribution page configuration, there is now a Terms & conditions tab
-![GDPR Membership t&C screenshot](/images/membershipt&c.png)
-- Complete the settings for where you want the t&c's checkbox located and complete the title you wouldlike to appear with a description if any 
+![GDPR Membership t&C screenshot](images/membershipt&c.png)
+- Complete the settings for where you want the t&c's checkbox located and complete the title you wouldlike to appear with a description if any
 - Under the Contribution links tab, click the live link to navigate to that contribution page
-![GDPR Manage Contribution screenshot](/images/managecontribution.png)
+![GDPR Manage Contribution screenshot](images/managecontribution.png)
 - The live contribution page now displays the membership terms & conditions
 - ![GDPR Membership Page screenshot](images/membershipt&cpage.png)

--- a/docs/right-to-be-forgotten.md
+++ b/docs/right-to-be-forgotten.md
@@ -6,7 +6,7 @@ Some of the examples include financial history including any tax related informa
 
 In order to allow a contact to be forgotten within CiviCRM, without comprising key meta data around the supporter, we have introduced a new button under the GDPR tab on each contact.
 
-![Communication Preferences Main](/images/forget-me-button-gdpr-tab.png)
+![Communication Preferences Main](images/forget-me-button-gdpr-tab.png)
 
 On pressing the button for a contact, the following actions will take place
 


### PR DESCRIPTION
mkdocs requires images without the leading / so all images are broken before this PR at https://docs.civicrm.org/gdpr/en/latest/