### PR TITLE
Use frontend_title and frontend_description as group defaults

### DIFF
--- a/CRM/Gdpr/Form/CommunicationsPreferences.php
+++ b/CRM/Gdpr/Form/CommunicationsPreferences.php
@@ -312,9 +312,7 @@ class CRM_Gdpr_Form_CommunicationsPreferences extends CRM_Core_Form {
       // If value is missing in the setting, take the corresponding value from the
       // group.
       foreach($map as $setting_key => $group_key) {
-        if (empty($item[$setting_key]) && !empty($grp[$group_key])) {
-          $item[$setting_key] = $grp[$group_key];
-        }
+        $item[$setting_key] = $item[$setting_key] ?? $grp['frontend_' . $group_key] ?? $grp[$group_key];
       }
       // Set default weight.
       if (empty($item['group_weight'])) {


### PR DESCRIPTION
 When setting defaults for group containter, look for frontend_title and frontend_description values for the group in core. (These fields are newish additions to core).

I think this would be a start to addressing https://github.com/veda-consulting-company/uk.co.vedaconsulting.gdpr/issues/261 .

Perhaps in the long run it would be cleaner to remove the customising functionality in the extension now?