### PR TITLE
Regenerate civix and cleanup for compatibility with recent CiviCRM versions

### DIFF
--- a/CRM/Gdpr/Form/UpdatePreference.php
+++ b/CRM/Gdpr/Form/UpdatePreference.php
@@ -84,10 +84,8 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
     }
 
     //Include reCAPTCHA?
-    if ($addCaptcha = $this->commPrefSettings['add_captcha']) {
-      $captcha = CRM_Utils_ReCAPTCHA::singleton();
-      $captcha->add($this);
-      $this->assign('isCaptcha', TRUE);
+    if ($this->commPrefSettings['add_captcha']) {
+      CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
     }
 
     //Inject channels and groups into comms preferenec form.
@@ -228,9 +226,7 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
       }
 
       if ($addCaptcha && !$viewOnly) {
-        $captcha = CRM_Utils_ReCAPTCHA::singleton();
-        $captcha->add($this);
-        $this->assign('isCaptcha', TRUE);
+        CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
       }
     }
   }

--- a/CRM/Gdpr/Form/UpdatePreference.php
+++ b/CRM/Gdpr/Form/UpdatePreference.php
@@ -85,7 +85,20 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
 
     //Include reCAPTCHA?
     if ($this->commPrefSettings['add_captcha']) {
-      CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
+      if (is_callable(['CRM_Utils_ReCAPTCHA', 'enableCaptchaOnForm'])) {
+        $button = substr($this->controller->getButtonName(), -4);
+        // We show reCAPTCHA for anonymous user if enabled.
+        // 'skip' button is on additional participant forms, we only show reCAPTCHA on the primary form.
+        if (!CRM_Core_Session::getLoggedInContactID() && ($button !== 'skip')) {
+          if (\Civi\Api4\UFGroup::get(FALSE)
+            ->addWhere('id', '=', $this->commPrefSettings['profile'])
+            ->execute()
+            ->first()['add_captcha']
+          ) {
+            CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
+          }
+        }
+      }
     }
 
     //Inject channels and groups into comms preferenec form.
@@ -160,20 +173,18 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
   /**
    * Add the custom fields.
    *
-   * @param int $id
+   * @param int $ufGroupID
    * @param string $name
    * @param bool $viewOnly
    */
-  public function buildCustom($id, $name = 'custom_pre', $viewOnly = FALSE) {
-    if ($id) {
+  public function buildCustom($ufGroupID, $name = 'custom_pre') {
+    if ($ufGroupID) {
       //For Profile form validation
-      $this->_gid = $id;
+      $this->_gid = $ufGroupID;
       $dao = new CRM_Core_DAO_UFGroup();
-      $dao->id = $id;
+      $dao->id = $ufGroupID;
       if ($dao->find(TRUE)) {
         $this->_isUpdateDupe = $dao->is_update_dupe; // Profile duplicate match option
-        // $this->_isUpdateDupe = $dao->is_update_dupe;
-        $this->_isAddCaptcha = $dao->add_captcha;
         $this->_ufGroup = (array) $dao;
       }
 
@@ -181,11 +192,11 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
       $contactID = $this->_cid;
 
       if ($contactID) {
-        CRM_Core_BAO_UFGroup::filterUFGroups($id, $contactID);
+        CRM_Core_BAO_UFGroup::filterUFGroups($ufGroupID, $contactID);
       }
 
       try {
-        $fields = CRM_Core_BAO_UFGroup::getFields($id, FALSE, CRM_Core_Action::ADD,
+        $fields = CRM_Core_BAO_UFGroup::getFields($ufGroupID, FALSE, CRM_Core_Action::ADD,
           NULL, NULL, FALSE, NULL,
           FALSE, NULL, CRM_Core_Permission::CREATE,
           'field_name', TRUE
@@ -196,37 +207,19 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
         CRM_Core_Error::debug_log_message('Please ensure that the Profile you have selected in the GDPR settings page exists and is enabled');
       }
 
-      $addCaptcha = FALSE;
-
       if (!empty($fields) && is_array($fields)) {
         $this->assign($name, $fields);
         foreach ($fields as $key => $field) {
-          if ($viewOnly &&
-            isset($field['data_type']) &&
-            $field['data_type'] == 'File' || ($viewOnly && $field['name'] == 'image_URL')
-          ) {
-            // ignore file upload fields
-            continue;
-          }
           //make the field optional if primary participant
           //have been skip the additional participant.
           if ($button == 'skip') {
             $field['is_required'] = FALSE;
-          }
-          // CRM-11316 Is ReCAPTCHA enabled for this profile AND is this an anonymous visitor
-          elseif ($field['add_captcha'] && !$contactID) {
-            // only add captcha for first page
-            $addCaptcha = TRUE;
           }
           $this->_mode = $contactID ? CRM_Profile_Form::MODE_EDIT : CRM_Profile_Form::MODE_CREATE;
           CRM_Core_BAO_UFGroup::buildProfile($this, $field, $this->_mode, $contactID, TRUE);
 
           $this->_fields[$key] = $field;
         }
-      }
-
-      if ($addCaptcha && !$viewOnly) {
-        CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
       }
     }
   }

--- a/CRM/Gdpr/Page/AJAX.php
+++ b/CRM/Gdpr/Page/AJAX.php
@@ -1,53 +1,26 @@
 <?php
-
 /*
  +--------------------------------------------------------------------+
- | CiviCRM version 4.7                                                |
- +--------------------------------------------------------------------+
- | Copyright CiviCRM LLC (c) 2004-2011                                |
- +--------------------------------------------------------------------+
- | This file is a part of CiviCRM.                                    |
+ | Copyright CiviCRM LLC. All rights reserved.                        |
  |                                                                    |
- | CiviCRM is free software; you can copy, modify, and distribute it  |
- | under the terms of the GNU Affero General Public License           |
- | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
- |                                                                    |
- | CiviCRM is distributed in the hope that it will be useful, but     |
- | WITHOUT ANY WARRANTY; without even the implied warranty of         |
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
- | See the GNU Affero General Public License for more details.        |
- |                                                                    |
- | You should have received a copy of the GNU Affero General Public   |
- | License and the CiviCRM Licensing Exception along                  |
- | with this program; if not, contact CiviCRM LLC                     |
- | at info[AT]civicrm[DOT]org. If you have questions about the        |
- | GNU Affero General Public License or the licensing of CiviCRM,     |
- | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
-*/
-
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2011
- * $Id$
- *
  */
-
-require_once 'CRM/Utils/Type.php';
 
 /**
  *  Class used to get historic addresses
  */
 class CRM_Gdpr_Page_AJAX {
+
   /**
    * Function to get address log for a contact
    */
   public static function get_address_logs($contactId){
-    
-    $aGetMemberships =array();
+    $aGetMemberships = [];
 
-    if(empty($contactId)){
+    if (empty($contactId)) {
       return $aGetMemberships;
     }
 
@@ -65,35 +38,33 @@ FROM {$logging_db}.log_civicrm_address as lca
 LEFT JOIN civicrm_location_type as lt ON ( lca.location_type_id = lt.id )
 WHERE lca.contact_id = %1
 ORDER BY lca.log_date DESC";
-      $sqlParams = array( 
-        1 => array( $contactId, 'Integer')
-      );
-      $dao = CRM_Core_DAO::executeQuery($sql, $sqlParams);
-      while($dao->fetch()){
-          $country  = empty($dao->country_id) ? Null  : CRM_Core_PseudoConstant::country( $dao->country_id );
-          $county   = empty($dao->county_id)  ? Null  : CRM_Core_PseudoConstant::county( $dao->county_id );
-          $aGetMemberships[] = array(
-            'street'        => $dao->street_address,
-            'location_type' => $dao->lt_name,
-            'postal_code'   => $dao->postal_code,
-            'country'       => $country,
-            'line1'         => $dao->supplemental_address_1,
-            'line2'         => $dao->supplemental_address_2,
-            'line3'         => $dao->supplemental_address_3,
-            'city'          => $dao->city,
-            'country'       => $country,
-            'county'        => $county,
-            'log_action'    => $dao->log_action,
-            'log_date'      => CRM_Utils_Date::customFormat($dao->log_date , '%d-%m-%Y')
-          );
-      }
-    //}
+    $sqlParams = [
+      1 => [$contactId, 'Integer']
+    ];
+    $dao = CRM_Core_DAO::executeQuery($sql, $sqlParams);
+    while ($dao->fetch()) {
+      $country  = empty($dao->country_id) ? NULL  : CRM_Core_PseudoConstant::country( $dao->country_id );
+      $county   = empty($dao->county_id)  ? NULL  : CRM_Core_PseudoConstant::county( $dao->county_id );
+      $aGetMemberships[] = [
+        'street'        => $dao->street_address,
+        'location_type' => $dao->lt_name,
+        'postal_code'   => $dao->postal_code,
+        'line1'         => $dao->supplemental_address_1,
+        'line2'         => $dao->supplemental_address_2,
+        'line3'         => $dao->supplemental_address_3,
+        'city'          => $dao->city,
+        'country'       => $country,
+        'county'        => $county,
+        'log_action'    => $dao->log_action,
+        'log_date'      => CRM_Utils_Date::customFormat($dao->log_date , '%d-%m-%Y')
+      ];
+    }
     return $aGetMemberships;
   }
-  
-  public static function get_address_history_table( $data ){
-    if(empty($data)){
-      return null;
+
+  public static function get_address_history_table($data) {
+    if (empty($data)) {
+      return NULL;
     }
     $table  = <<< TABLE
       <table id="custom_address_history">
@@ -121,50 +92,47 @@ ORDER BY lca.log_date DESC";
         </thead>
     <tbody>
 TABLE;
-    
-        
-        foreach( $data as $row ){
-         $table  .= "<tr> ";
-         $table  .= "<td valign='top'> ".$row['log_date']."</td> ";
-         $table  .= "<td valign='top'> ".$row['log_action']."</td> ";
-         $table  .= "<td valign='top'> ".$row['location_type']."</td> ";
-         $table  .= "<td valign='top'> ".$row['street'];
-         if(!empty( $row['line1'])){
-           $table .= "<br>".$row['line1'];
-         }
-         if(!empty( $row['line2'])){
-           $table .= "<br>".$row['line2'];
-         }
-         if(!empty( $row['line3'])){
-           $table .= "<br>".$row['line3'];
-         }
-         if(!empty( $row['city'])){
-           $table .= "<br>".$row['city'];
-         }
-         $table  .= "</td>";
-         $table  .= "<td valign='top'> ".$row['postal_code']."</td> ";
-         $table  .= "<td valign='top'> ".$row['country']."</td> ";
-         $table  .= "</tr> ";
-         
-        }
-     
+
+    foreach ($data as $row) {
+      $table  .= "<tr> ";
+      $table  .= "<td valign='top'> ".$row['log_date']."</td> ";
+      $table  .= "<td valign='top'> ".$row['log_action']."</td> ";
+      $table  .= "<td valign='top'> ".$row['location_type']."</td> ";
+      $table  .= "<td valign='top'> ".$row['street'];
+      if(!empty( $row['line1'])){
+        $table .= "<br>".$row['line1'];
+      }
+      if(!empty( $row['line2'])){
+        $table .= "<br>".$row['line2'];
+      }
+      if(!empty( $row['line3'])){
+        $table .= "<br>".$row['line3'];
+      }
+      if(!empty( $row['city'])){
+        $table .= "<br>".$row['city'];
+      }
+      $table  .= "</td>";
+      $table  .= "<td valign='top'> ".$row['postal_code']."</td> ";
+      $table  .= "<td valign='top'> ".$row['country']."</td> ";
+      $table  .= "</tr> ";
+    }
+
     $table .= <<<TABLE
           </tbody>
-        
+
         </table>
 TABLE;
-    
-    
+
     return $table;
   }
 
-  static function getAddressHistory(){
+  public static function getAddressHistory() {
     $iContactId = $_POST['contactId'];
     if(!empty($iContactId)){
       $aGetAddressHistory = self::get_address_logs( $iContactId );
       $table = self::get_address_history_table( $aGetAddressHistory );
     }
-    
+
     $countHistory = count($aGetAddressHistory);
     //$return['table'] = $table;
     //echo json_encode($return);
@@ -180,11 +148,11 @@ TABLE;
    * Function to get GDPR activity contact list
    */
   public static function getGdprActivityContactList() {
-    $sortMapper = array(
+    $sortMapper = [
       0 => 'contact_a.id',
       1 => 'contact_a.sort_name',
       //2 => 'a.activity_date_time',
-    );
+    ];
 
     $sEcho = CRM_Utils_Type::escape($_REQUEST['sEcho'], 'Integer');
     $offset = isset($_REQUEST['iDisplayStart']) ? CRM_Utils_Type::escape($_REQUEST['iDisplayStart'], 'Integer') : 0;
@@ -211,11 +179,11 @@ TABLE;
 
     $iFilteredTotal = $iTotal = $params['total'];
 
-    $selectorElements = array(
+    $selectorElements = [
       'id',
       'sort_name',
       //'activity_date_time',
-    );
+    ];
 
     header("Content-Type: application/json");
     echo CRM_Utils_JSON::encodeDataTableSelector($contactList, $sEcho, $iTotal, $iFilteredTotal, $selectorElements);
@@ -225,7 +193,7 @@ TABLE;
   /**
    * To handle the comms preference submission from Thank you page Event/Contribution page.
    */
-  static function commPreferenceSubmission(){
+  public static function commPreferenceSubmission() {
     $iContactId = $_POST['contactId'];
     $checksum = $_POST['contact_cs'];
     $submittedValues = $_POST['preference'];
@@ -238,7 +206,7 @@ TABLE;
     //Update preferences
     CRM_Gdpr_CommunicationsPreferences_Utils::updateCommsPrefByFormValues($iContactId, $submittedValues);
 
-    //Create comms preference activity 
+    //Create comms preference activity
     CRM_Gdpr_CommunicationsPreferences_Utils::createCommsPrefActivity($iContactId, $submittedValues);
 
     //Get completion msg from settings
@@ -254,10 +222,11 @@ TABLE;
     CRM_Utils_System::civiExit();
   }
 
-  static function reRunInstallationCustomData() {
+  public static function reRunInstallationCustomData() {
     CRM_Gdpr_Utils::reRunInstallationCustomXML();
 
     echo "Custom Data XMl processed successfully";
     CRM_Utils_System::civiExit();
   }
+
 }

--- a/CRM/Gdpr/Upgrader.php
+++ b/CRM/Gdpr/Upgrader.php
@@ -36,34 +36,34 @@ class CRM_Gdpr_Upgrader extends CRM_Gdpr_Upgrader_Base {
    */
   public function uninstall() {
     // Delete 'GDPR Cancelled' membership status
-    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'get', array(
+    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'get', [
       'sequential' => 1,
-      'return' => array("id"),
+      'return' => ["id"],
       'name' => "GDPR_Cancelled",
-      'api.MembershipStatus.delete' => array(
+      'api.MembershipStatus.delete' => [
         'id' => "\$value.id",
-      ),
-    ));
+      ],
+    ]);
 
     // Delete 'Contacts without any activity for a period' custom search
-    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('CustomSearch', 'get', array(
+    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('CustomSearch', 'get', [
       'sequential' => 1,
-      'return' => array("id"),
+      'return' => ["id"],
       'name' => "CRM_Gdpr_Form_Search_ActivityContact",
-      'api.CustomSearch.delete' => array(
+      'api.CustomSearch.delete' => [
         'id' => "\$value.id",
-      ),
-    ));
+      ],
+    ]);
 
     // Delete 'Search Group Subscription by Date Range' custom search
-    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('CustomSearch', 'get', array(
+    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('CustomSearch', 'get', [
       'sequential' => 1,
-      'return' => array("id"),
+      'return' => ["id"],
       'name' => "CRM_Gdpr_Form_Search_GroupcontactDetails",
-      'api.CustomSearch.delete' => array(
+      'api.CustomSearch.delete' => [
         'id' => "\$value.id",
-      ),
-    ));
+      ],
+    ]);
 
     // Delete custom data.
     $result = civicrm_api3('CustomGroup', 'get', [
@@ -100,15 +100,15 @@ class CRM_Gdpr_Upgrader extends CRM_Gdpr_Upgrader_Base {
    */
   public function enable() {
     // Enable 'GDPR Cancelled' membership status
-    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'get', array(
+    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'get', [
       'sequential' => 1,
-      'return' => array("id"),
+      'return' => ["id"],
       'name' => "GDPR_Cancelled",
-      'api.MembershipStatus.create' => array(
+      'api.MembershipStatus.create' => [
         'id' => "\$value.id",
         'is_active' => 1,
-      ),
-    ));
+      ],
+    ]);
 
     $this->addMsgTemplateGDPR();
   }
@@ -118,15 +118,15 @@ class CRM_Gdpr_Upgrader extends CRM_Gdpr_Upgrader_Base {
    */
   public function disable() {
     // Disable 'GDPR Cancelled' membership status
-    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'get', array(
+    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'get', [
       'sequential' => 1,
-      'return' => array("id"),
+      'return' => ["id"],
       'name' => "GDPR_Cancelled",
-      'api.MembershipStatus.create' => array(
+      'api.MembershipStatus.create' => [
         'id' => "\$value.id",
         'is_active' => 0,
-      ),
-    ));
+      ],
+    ]);
   }
 
   /**
@@ -138,14 +138,14 @@ class CRM_Gdpr_Upgrader extends CRM_Gdpr_Upgrader_Base {
   public function upgrade_1100() {
     $this->log('Applying update 1100');
     // Create 'Contacts without any activity for a period' custom search by API
-    CRM_Gdpr_Utils::CiviCRMAPIWrapper('CustomSearch', 'create', array(
+    CRM_Gdpr_Utils::CiviCRMAPIWrapper('CustomSearch', 'create', [
       'sequential' => 1,
       'option_group_id' => "custom_search",
       'name' => "CRM_Gdpr_Form_Search_ActivityContact",
       'is_active' => 1,
       'label' => "CRM_Gdpr_Form_Search_ActivityContact",
       'description' => E::ts("Contacts without any activity for a period"),
-    ));
+    ]);
     return TRUE;
   }
 
@@ -233,15 +233,15 @@ class CRM_Gdpr_Upgrader extends CRM_Gdpr_Upgrader_Base {
     }
 
     // Get max weight for membership status
-    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'get', array(
+    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'get', [
       'sequential' => 1,
-      'return' => array("weight"),
-      'options' => array('sort' => "weight DESC", 'limit' => 1),
-    ));
+      'return' => ["weight"],
+      'options' => ['sort' => "weight DESC", 'limit' => 1],
+    ]);
     $weight = $result['values'][0]['weight'] + 1;
 
     // Create 'GDPR Cancelled' membership status
-    CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'create', array(
+    CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'create', [
       'name' => "GDPR_Cancelled",
       'label' => E::ts("GDPR Cancelled"),
       'is_admin' => 1, // Is Admin Only
@@ -249,7 +249,7 @@ class CRM_Gdpr_Upgrader extends CRM_Gdpr_Upgrader_Base {
       'is_reserved' => 1, // Is reserved, so that users cannot delete it
       'is_current_member' => 0,
       'weight' => $weight,
-    ));
+    ]);
   }
 
   private function log($message) {

--- a/CRM/Gdpr/Upgrader/Base.php
+++ b/CRM/Gdpr/Upgrader/Base.php
@@ -9,9 +9,9 @@ use CRM_Gdpr_ExtensionUtil as E;
 class CRM_Gdpr_Upgrader_Base {
 
   /**
-   * @var varies, subclass of ttis
+   * @var CRM_Gdpr_Upgrader_Base
    */
-  static $instance;
+  public static $instance;
 
   /**
    * @var CRM_Queue_TaskContext
@@ -19,22 +19,25 @@ class CRM_Gdpr_Upgrader_Base {
   protected $ctx;
 
   /**
-   * @var string, eg 'com.example.myextension'
+   * @var string
+   *   eg 'com.example.myextension'
    */
   protected $extensionName;
 
   /**
-   * @var string, full path to the extension's source tree
+   * @var string
+   *   full path to the extension's source tree
    */
   protected $extensionDir;
 
   /**
-   * @var array(revisionNumber) sorted numerically
+   * @var array
+   *   sorted numerically
    */
   private $revisions;
 
   /**
-   * @var boolean
+   * @var bool
    *   Flag to clean up extension revision data in civicrm_setting
    */
   private $revisionStorageIsDeprecated = FALSE;
@@ -42,12 +45,11 @@ class CRM_Gdpr_Upgrader_Base {
   /**
    * Obtain a reference to the active upgrade handler.
    */
-  static public function instance() {
+  public static function instance() {
     if (!self::$instance) {
-      // FIXME auto-generate
       self::$instance = new CRM_Gdpr_Upgrader(
         'uk.co.vedaconsulting.gdpr',
-        realpath(__DIR__ . '/../../../')
+        E::path()
       );
     }
     return self::$instance;
@@ -59,19 +61,25 @@ class CRM_Gdpr_Upgrader_Base {
    * Note: Each upgrader instance should only be associated with one
    * task-context; otherwise, this will be non-reentrant.
    *
-   * @code
+   * ```
    * CRM_Gdpr_Upgrader_Base::_queueAdapter($ctx, 'methodName', 'arg1', 'arg2');
-   * @endcode
+   * ```
    */
-  static public function _queueAdapter() {
+  public static function _queueAdapter() {
     $instance = self::instance();
     $args = func_get_args();
     $instance->ctx = array_shift($args);
     $instance->queue = $instance->ctx->queue;
     $method = array_shift($args);
-    return call_user_func_array(array($instance, $method), $args);
+    return call_user_func_array([$instance, $method], $args);
   }
 
+  /**
+   * CRM_Gdpr_Upgrader_Base constructor.
+   *
+   * @param $extensionName
+   * @param $extensionDir
+   */
   public function __construct($extensionName, $extensionDir) {
     $this->extensionName = $extensionName;
     $this->extensionDir = $extensionDir;
@@ -82,7 +90,8 @@ class CRM_Gdpr_Upgrader_Base {
   /**
    * Run a CustomData file.
    *
-   * @param string $relativePath the CustomData XML file path (relative to this extension's dir)
+   * @param string $relativePath
+   *   the CustomData XML file path (relative to this extension's dir)
    * @return bool
    */
   public function executeCustomDataFile($relativePath) {
@@ -93,11 +102,12 @@ class CRM_Gdpr_Upgrader_Base {
   /**
    * Run a CustomData file
    *
-   * @param string $xml_file  the CustomData XML file path (absolute path)
+   * @param string $xml_file
+   *   the CustomData XML file path (absolute path)
    *
    * @return bool
    */
-  protected static function executeCustomDataFileByAbsPath($xml_file) {
+  protected function executeCustomDataFileByAbsPath($xml_file) {
     $import = new CRM_Utils_Migrate_Import();
     $import->run($xml_file);
     return TRUE;
@@ -106,7 +116,8 @@ class CRM_Gdpr_Upgrader_Base {
   /**
    * Run a SQL file.
    *
-   * @param string $relativePath the SQL file path (relative to this extension's dir)
+   * @param string $relativePath
+   *   the SQL file path (relative to this extension's dir)
    *
    * @return bool
    */
@@ -119,10 +130,14 @@ class CRM_Gdpr_Upgrader_Base {
   }
 
   /**
+   * Run the sql commands in the specified file.
+   *
    * @param string $tplFile
    *   The SQL file path (relative to this extension's dir).
    *   Ex: "sql/mydata.mysql.tpl".
+   *
    * @return bool
+   * @throws \CRM_Core_Exception
    */
   public function executeSqlTemplate($tplFile) {
     // Assign multilingual variable to Smarty.
@@ -141,17 +156,19 @@ class CRM_Gdpr_Upgrader_Base {
    * Run one SQL query.
    *
    * This is just a wrapper for CRM_Core_DAO::executeSql, but it
-   * provides syntatic sugar for queueing several tasks that
+   * provides syntactic sugar for queueing several tasks that
    * run different queries
+   *
+   * @return bool
    */
-  public function executeSql($query, $params = array()) {
+  public function executeSql($query, $params = []) {
     // FIXME verify that we raise an exception on error
     CRM_Core_DAO::executeQuery($query, $params);
     return TRUE;
   }
 
   /**
-   * Syntatic sugar for enqueuing a task which calls a function in this class.
+   * Syntactic sugar for enqueuing a task which calls a function in this class.
    *
    * The task is weighted so that it is processed
    * as part of the currently-pending revision.
@@ -163,11 +180,11 @@ class CRM_Gdpr_Upgrader_Base {
     $args = func_get_args();
     $title = array_shift($args);
     $task = new CRM_Queue_Task(
-      array(get_class($this), '_queueAdapter'),
+      [get_class($this), '_queueAdapter'],
       $args,
       $title
     );
-    return $this->queue->createItem($task, array('weight' => -1));
+    return $this->queue->createItem($task, ['weight' => -1]);
   }
 
   // ******** Revision-tracking helpers ********
@@ -193,6 +210,8 @@ class CRM_Gdpr_Upgrader_Base {
 
   /**
    * Add any pending revisions to the queue.
+   *
+   * @param CRM_Queue_Queue $queue
    */
   public function enqueuePendingRevisions(CRM_Queue_Queue $queue) {
     $this->queue = $queue;
@@ -200,23 +219,23 @@ class CRM_Gdpr_Upgrader_Base {
     $currentRevision = $this->getCurrentRevision();
     foreach ($this->getRevisions() as $revision) {
       if ($revision > $currentRevision) {
-        $title = E::ts('Upgrade %1 to revision %2', array(
+        $title = E::ts('Upgrade %1 to revision %2', [
           1 => $this->extensionName,
           2 => $revision,
-        ));
+        ]);
 
         // note: don't use addTask() because it sets weight=-1
 
         $task = new CRM_Queue_Task(
-          array(get_class($this), '_queueAdapter'),
-          array('upgrade_' . $revision),
+          [get_class($this), '_queueAdapter'],
+          ['upgrade_' . $revision],
           $title
         );
         $this->queue->createItem($task);
 
         $task = new CRM_Queue_Task(
-          array(get_class($this), '_queueAdapter'),
-          array('setCurrentRevision', $revision),
+          [get_class($this), '_queueAdapter'],
+          ['setCurrentRevision', $revision],
           $title
         );
         $this->queue->createItem($task);
@@ -227,11 +246,12 @@ class CRM_Gdpr_Upgrader_Base {
   /**
    * Get a list of revisions.
    *
-   * @return array(revisionNumbers) sorted numerically
+   * @return array
+   *   revisionNumbers sorted numerically
    */
   public function getRevisions() {
     if (!is_array($this->revisions)) {
-      $this->revisions = array();
+      $this->revisions = [];
 
       $clazz = new ReflectionClass(get_class($this));
       $methods = $clazz->getMethods();
@@ -256,7 +276,7 @@ class CRM_Gdpr_Upgrader_Base {
 
   private function getCurrentRevisionDeprecated() {
     $key = $this->extensionName . ':version';
-    if ($revision = CRM_Core_BAO_Setting::getItem('Extension', $key)) {
+    if ($revision = \Civi::settings()->get($key)) {
       $this->revisionStorageIsDeprecated = TRUE;
     }
     return $revision;
@@ -281,7 +301,7 @@ class CRM_Gdpr_Upgrader_Base {
   // ******** Hook delegates ********
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
    */
   public function onInstall() {
     $files = glob($this->extensionDir . '/sql/*_install.sql');
@@ -302,26 +322,26 @@ class CRM_Gdpr_Upgrader_Base {
         $this->executeCustomDataFileByAbsPath($file);
       }
     }
-    if (is_callable(array($this, 'install'))) {
+    if (is_callable([$this, 'install'])) {
       $this->install();
     }
   }
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
    */
   public function onPostInstall() {
     $revisions = $this->getRevisions();
     if (!empty($revisions)) {
       $this->setCurrentRevision(max($revisions));
     }
-    if (is_callable(array($this, 'postInstall'))) {
+    if (is_callable([$this, 'postInstall'])) {
       $this->postInstall();
     }
   }
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
    */
   public function onUninstall() {
     $files = glob($this->extensionDir . '/sql/*_uninstall.mysql.tpl');
@@ -330,7 +350,7 @@ class CRM_Gdpr_Upgrader_Base {
         $this->executeSqlTemplate($file);
       }
     }
-    if (is_callable(array($this, 'uninstall'))) {
+    if (is_callable([$this, 'uninstall'])) {
       $this->uninstall();
     }
     $files = glob($this->extensionDir . '/sql/*_uninstall.sql');
@@ -342,21 +362,21 @@ class CRM_Gdpr_Upgrader_Base {
   }
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
    */
   public function onEnable() {
     // stub for possible future use
-    if (is_callable(array($this, 'enable'))) {
+    if (is_callable([$this, 'enable'])) {
       $this->enable();
     }
   }
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
    */
   public function onDisable() {
     // stub for possible future use
-    if (is_callable(array($this, 'disable'))) {
+    if (is_callable([$this, 'disable'])) {
       $this->disable();
     }
   }
@@ -364,7 +384,7 @@ class CRM_Gdpr_Upgrader_Base {
   public function onUpgrade($op, CRM_Queue_Queue $queue = NULL) {
     switch ($op) {
       case 'check':
-        return array($this->hasPendingRevisions());
+        return [$this->hasPendingRevisions()];
 
       case 'enqueue':
         return $this->enqueuePendingRevisions($queue);

--- a/CRM/Gdpr/Utils.php
+++ b/CRM/Gdpr/Utils.php
@@ -681,7 +681,12 @@ WHERE url.time_stamp > '{$date}'";
     $import = new CRM_Utils_Migrate_Import();
     foreach (array('CustomData_v1', 'CustomGroupData') as $fileName) {
       $file = E::path("xml/{$fileName}.xml");
-      $import->run($file);
+      try {
+        $import->run($file);
+      }
+      catch (Exception $e) {
+        // Do nothing, sometimes it fails with "already exists"
+      }
     }
   }
 

--- a/gdpr.civix.php
+++ b/gdpr.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_Gdpr_ExtensionUtil {
-  const SHORT_NAME = "gdpr";
-  const LONG_NAME = "uk.co.vedaconsulting.gdpr";
-  const CLASS_PREFIX = "CRM_Gdpr";
+  const SHORT_NAME = 'gdpr';
+  const LONG_NAME = 'uk.co.vedaconsulting.gdpr';
+  const CLASS_PREFIX = 'CRM_Gdpr';
 
   /**
    * Translate a string using the extension's domain.
@@ -24,9 +24,9 @@ class CRM_Gdpr_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = array()) {
+  public static function ts($text, $params = []) {
     if (!array_key_exists('domain', $params)) {
-      $params['domain'] = array(self::LONG_NAME, NULL);
+      $params['domain'] = [self::LONG_NAME, NULL];
     }
     return ts($text, $params);
   }
@@ -82,7 +82,7 @@ use CRM_Gdpr_ExtensionUtil as E;
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _gdpr_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
@@ -100,7 +100,7 @@ function _gdpr_civix_civicrm_config(&$config = NULL) {
     array_unshift($template->template_dir, $extDir);
   }
   else {
-    $template->template_dir = array($extDir, $template->template_dir);
+    $template->template_dir = [$extDir, $template->template_dir];
   }
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
@@ -112,7 +112,7 @@ function _gdpr_civix_civicrm_config(&$config = NULL) {
  *
  * @param $files array(string)
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
 function _gdpr_civix_civicrm_xmlMenu(&$files) {
   foreach (_gdpr_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
@@ -123,7 +123,7 @@ function _gdpr_civix_civicrm_xmlMenu(&$files) {
 /**
  * Implements hook_civicrm_install().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _gdpr_civix_civicrm_install() {
   _gdpr_civix_civicrm_config();
@@ -135,12 +135,12 @@ function _gdpr_civix_civicrm_install() {
 /**
  * Implements hook_civicrm_postInstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
 function _gdpr_civix_civicrm_postInstall() {
   _gdpr_civix_civicrm_config();
   if ($upgrader = _gdpr_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onPostInstall'))) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
       $upgrader->onPostInstall();
     }
   }
@@ -149,7 +149,7 @@ function _gdpr_civix_civicrm_postInstall() {
 /**
  * Implements hook_civicrm_uninstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _gdpr_civix_civicrm_uninstall() {
   _gdpr_civix_civicrm_config();
@@ -161,12 +161,12 @@ function _gdpr_civix_civicrm_uninstall() {
 /**
  * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _gdpr_civix_civicrm_enable() {
   _gdpr_civix_civicrm_config();
   if ($upgrader = _gdpr_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onEnable'))) {
+    if (is_callable([$upgrader, 'onEnable'])) {
       $upgrader->onEnable();
     }
   }
@@ -175,13 +175,13 @@ function _gdpr_civix_civicrm_enable() {
 /**
  * (Delegated) Implements hook_civicrm_disable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  * @return mixed
  */
 function _gdpr_civix_civicrm_disable() {
   _gdpr_civix_civicrm_config();
   if ($upgrader = _gdpr_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onDisable'))) {
+    if (is_callable([$upgrader, 'onDisable'])) {
       $upgrader->onDisable();
     }
   }
@@ -193,10 +193,11 @@ function _gdpr_civix_civicrm_disable() {
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _gdpr_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _gdpr_civix_upgrader()) {
@@ -217,22 +218,23 @@ function _gdpr_civix_upgrader() {
 }
 
 /**
- * Search directory tree for files which match a glob pattern
+ * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
  * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
  *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
+ *
+ * @return array
  */
 function _gdpr_civix_find_files($dir, $pattern) {
-  if (is_callable(array('CRM_Utils_File', 'findFiles'))) {
+  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
     return CRM_Utils_File::findFiles($dir, $pattern);
   }
 
-  $todos = array($dir);
-  $result = array();
+  $todos = [$dir];
+  $result = [];
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_gdpr_civix_glob("$subdir/$pattern") as $match) {
@@ -243,7 +245,7 @@ function _gdpr_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         }
         elseif (is_dir($path)) {
           $todos[] = $path;
@@ -254,25 +256,27 @@ function _gdpr_civix_find_files($dir, $pattern) {
   }
   return $result;
 }
+
 /**
  * (Delegated) Implements hook_civicrm_managed().
  *
  * Find any *.mgd.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
 function _gdpr_civix_civicrm_managed(&$entities) {
   $mgdFiles = _gdpr_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
   foreach ($mgdFiles as $file) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
         $e['module'] = E::LONG_NAME;
       }
-      $entities[] = $e;
       if (empty($e['params']['version'])) {
         $e['params']['version'] = '3';
       }
+      $entities[] = $e;
     }
   }
 }
@@ -284,7 +288,7 @@ function _gdpr_civix_civicrm_managed(&$entities) {
  *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _gdpr_civix_civicrm_caseTypes(&$caseTypes) {
   if (!is_dir(__DIR__ . '/xml/case')) {
@@ -295,14 +299,13 @@ function _gdpr_civix_civicrm_caseTypes(&$caseTypes) {
     $name = preg_replace('/\.xml$/', '', basename($file));
     if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
       $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // throw new CRM_Core_Exception($errorMessage);
+      throw new CRM_Core_Exception($errorMessage);
     }
-    $caseTypes[$name] = array(
+    $caseTypes[$name] = [
       'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
-    );
+    ];
   }
 }
 
@@ -313,7 +316,7 @@ function _gdpr_civix_civicrm_caseTypes(&$caseTypes) {
  *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _gdpr_civix_civicrm_angularModules(&$angularModules) {
   if (!is_dir(__DIR__ . '/ang')) {
@@ -332,6 +335,25 @@ function _gdpr_civix_civicrm_angularModules(&$angularModules) {
 }
 
 /**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _gdpr_civix_civicrm_themes(&$themes) {
+  $files = _gdpr_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
+  }
+}
+
+/**
  * Glob wrapper which is guaranteed to return an array.
  *
  * The documentation for glob() says, "On some systems it is impossible to
@@ -341,29 +363,34 @@ function _gdpr_civix_civicrm_angularModules(&$angularModules) {
  *
  * @link http://php.net/glob
  * @param string $pattern
- * @return array, possibly empty
+ *
+ * @return array
  */
 function _gdpr_civix_glob($pattern) {
   $result = glob($pattern);
-  return is_array($result) ? $result : array();
+  return is_array($result) ? $result : [];
 }
 
 /**
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
  * @param array $menu - menu hierarchy
- * @param string $path - path where insertion should happen (ie. Administer/System Settings)
- * @param array $item - menu you need to insert (parent/child attributes will be filled for you)
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
  */
 function _gdpr_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    $menu[] = array(
-      'attributes' => array_merge(array(
+    $menu[] = [
+      'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-      ), $item),
-    );
+      ], $item),
+    ];
     return TRUE;
   }
   else {
@@ -374,9 +401,9 @@ function _gdpr_civix_insert_navigation_menu(&$menu, $path, $item) {
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
         if (!isset($entry['child'])) {
-          $entry['child'] = array();
+          $entry['child'] = [];
         }
-        $found = _gdpr_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        $found = _gdpr_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -387,7 +414,7 @@ function _gdpr_civix_insert_navigation_menu(&$menu, $path, $item) {
  * (Delegated) Implements hook_civicrm_navigationMenu().
  */
 function _gdpr_civix_navigationMenu(&$nodes) {
-  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
     _gdpr_civix_fixNavigationMenu($nodes);
   }
 }
@@ -429,17 +456,22 @@ function _gdpr_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
 /**
  * (Delegated) Implements hook_civicrm_alterSettingsFolders().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
  */
 function _gdpr_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
-
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function _gdpr_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, []);
 }

--- a/gdpr.php
+++ b/gdpr.php
@@ -29,19 +29,18 @@ function gdpr_civicrm_xmlMenu(&$files) {
  */
 function gdpr_civicrm_install() {
   // #188 - use install instead of managed entities hook to avoid fatal
-  $result = civicrm_api3('OptionValue', 'get', array(
+  $result = civicrm_api3('OptionValue', 'get', [
     'sequential'      => 1,
     'option_group_id' => "cg_extend_objects",
     'value'           => "ContributionPage",
-  ));
+  ]);
   if (empty($result['id'])) {
-    $result = civicrm_api3('OptionValue', 'create', [
+    civicrm_api3('OptionValue', 'create', [
       'label'           => E::ts('Contribution Page'),
       'name'            => 'civicrm_contribution_page',
       'value'           => 'ContributionPage',
       'option_group_id' => 'cg_extend_objects',
       'is_active'       => 1,
-      'version'         => 3,
     ]);
   }
   _gdpr_civix_civicrm_install();
@@ -62,20 +61,20 @@ function gdpr_civicrm_postInstall() {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
  */
 function gdpr_civicrm_uninstall() {
-  $result = civicrm_api3('CustomGroup', 'get', array(
+  $result = civicrm_api3('CustomGroup', 'get', [
     'sequential' => 1,
     'extends'    => "ContributionPage",
-  ));
+  ]);
   if (!$result['is_error'] && $result['count'] <= 0) {
-    $result = civicrm_api3('OptionValue', 'get', array(
+    $result = civicrm_api3('OptionValue', 'get', [
       'sequential'      => 1,
       'option_group_id' => "cg_extend_objects",
       'value'           => "ContributionPage",
-    ));
+    ]);
     if (!empty($result['id'])) {
-      $result = civicrm_api3('OptionValue', 'delete', array(
+      civicrm_api3('OptionValue', 'delete', [
         'id' => $result['id'],
-      ));
+      ]);
     }
   }
   _gdpr_civix_civicrm_uninstall();
@@ -267,9 +266,9 @@ function gdpr_civicrm_buildForm($formName, $form) {
     if (!empty($cid)) {
       $templatePath = realpath(dirname(__FILE__).'/templates');
       CRM_Core_Region::instance('page-body')->add(
-        array(
+        [
           'template' => "{$templatePath}/CRM/Gdpr/Event/ThankYou.tpl"
-        )
+        ]
       );
 
       //amend communication preference link/embed form in thank you page
@@ -289,9 +288,9 @@ function gdpr_civicrm_buildForm($formName, $form) {
     if ($cid) {
       $templatePath = realpath(dirname(__FILE__) . '/templates');
       CRM_Core_Region::instance('page-body')->add(
-        array(
+        [
           'template' => "{$templatePath}/CRM/Gdpr/Event/ThankYou.tpl"
-        )
+        ]
       );
       //amend communication preference link/embed form in thank you page
       CRM_Gdpr_CommunicationsPreferences_Utils::commsPreferenceInThankyouPage($cid, $form, 'ContributionPage');
@@ -304,7 +303,7 @@ function gdpr_civicrm_buildForm($formName, $form) {
       $nullRef = NULL;
       $cs = CRM_Utils_Request::retrieve('cs', 'String', $nullRef, FALSE, NULL, 'GET');
       $cid = CRM_Utils_Request::retrieve('cid', 'Int', $nullRef, FALSE, NULL, 'GET');
-      $urlParams = array('reset' => 1);
+      $urlParams = ['reset' => 1];
       if ($cid && $cs) {
         $urlParams['cid'] = $cid;
         $urlParams['cs'] = $cs;
@@ -332,8 +331,8 @@ function gdpr_civicrm_postProcess($formName, $form) {
       $tc = new CRM_Gdpr_SLA_ContributionPage($contribution_page_id);
       if ($tc->isEnabled(TRUE)) {
         $tc->recordAcceptance($contact_id);
-	CRM_Gdpr_SLA_Utils::recordSLAAcceptance($contact_id);
-	$form->_params['gdprAccepted'] = TRUE;
+        CRM_Gdpr_SLA_Utils::recordSLAAcceptance($contact_id);
+        $form->_params['gdprAccepted'] = TRUE;
       }
     }
   }
@@ -406,30 +405,30 @@ function gdpr_civicrm_export($exportTempTable, $headerRows, $sqlColumns, $export
 function _gdpr_addTermsConditionsTab(&$tabs, $entityType, $id) {
   switch ($entityType) {
     case 'event' :
-      $urlParams = array(
+      $urlParams = [
         'path' => 'civicrm/event/manage/terms_conditions',
         'qs' => 'reset=1&id=' . $id,
-      );
-    break;
+      ];
+      break;
 
     case 'contribution_page' :
-      $urlParams = array(
+      $urlParams = [
         'path' => 'civicrm/admin/contribute/terms_conditions',
         'qs' => 'reset=1&action=update&id=' . $id,
-      );
-    break;
+      ];
+      break;
 
     default:
       return;
   }
 
   $url = CRM_Utils_System::url($urlParams['path'], $urlParams['qs']);
-  $tabs['terms_conditions'] = array(
+  $tabs['terms_conditions'] = [
     'title' => E::ts('Terms &amp; Conditions'),
     'url' => $url,
     'active' => TRUE,
     'class' => 'ajaxForm',
-  );
+  ];
 }
 
 /*
@@ -446,12 +445,13 @@ function gdpr_civicrm_tabs(&$tabs, $contactID) {
 
 function _gdpr_addGDPRTab(&$tabs, $contactID) {
   $url = CRM_Utils_System::url('civicrm/gdpr/view/tab', "reset=1&cid={$contactID}");
-  $tabs[] = array( 'id'    => 'gdprTab',
+  $tabs[] = [
+    'id'    => 'gdprTab',
     'url'   => $url,
     'title' => E::ts('GDPR'),
     'weight' => 300,
     'class'  => 'livePage',
-  );
+  ];
 }
 
 /**
@@ -465,62 +465,38 @@ function _gdpr_isCiviCRMVersion47(){
 /**
  * Add navigation for GDPR Dashboard
  *
- * @param $params associated array of navigation menus
+ * @param array $menu associated array of navigation menus
  */
-function gdpr_civicrm_navigationMenu( &$params ) {
-  // get the id of Contacts Menu
-  // MV #9990, to get contact menu id including multi domain.
-  // CRM_Core_DAO::getFieldValue wouldn't return if more than one available.
-  // then we end up with no GDPR menu link not appear on list even though have enough permission.
-  // so use domain id in query to get contact menu id.
-  // $contactsMenuId = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_Navigation', 'Contacts', 'id', 'name');
-  $domainID = CRM_Core_Config::domainID();
-  $sqlParams = array(
-    1 => array('Contacts', 'String'),
-    2 => array($domainID, 'Integer'),
-  );
-  $contactsMenuId = CRM_Core_DAO::singleValueQuery("
-    SELECT id FROM civicrm_navigation WHERE name = %1 AND domain_id = %2 AND is_active = 1
-  ", $sqlParams);
-
-  // skip adding menu if there is no contacts menu
-  if ($contactsMenuId) {
-    // get the maximum key under contacts menu
-    $maxKey = max( array_keys($params[$contactsMenuId]['child']));
-    $params[$contactsMenuId]['child'][$maxKey+1] =  array (
-      'attributes' => array (
-        'label'      => E::ts('GDPR Dashboard'),
-        'name'       => 'GDPR Dashboard',
-        'url'        => CRM_Utils_System::url('civicrm/gdpr/dashboard', 'reset=1'),
-        'permission' => 'access GDPR',
-        'operator'   => NULL,
-        'separator'  => FALSE,
-        'parentID'   => $contactsMenuId,
-        'navID'      => $maxKey+1,
-        'active'     => 1
-      )
-    );
-  }
+function gdpr_civicrm_navigationMenu(&$menu) {
+  _gdpr_civix_insert_navigation_menu($menu, 'Contacts', [
+    'label' => E::ts('GDPR Dashboard'),
+    'name' => 'GDPR Dashboard',
+    'url' => 'civicrm/gdpr/dashboard',
+    'permission' => 'access GDPR',
+    'operator' => 'OR',
+    'separator' => 0,
+  ]);
+  _gdpr_civix_navigationMenu($menu);
 }
 
 /**
  * implementation of hook_civicrm_token
  */
-function gdpr_civicrm_tokens( &$tokens ){
-  //Keeping this token only to sustain the old tokens otherwise,
-  //the token 'CommunicationPreferences' can be used in all places
+function gdpr_civicrm_tokens(&$tokens) {
+  // Keeping this token only to sustain the old tokens otherwise,
+  // the token 'CommunicationPreferences' can be used in all places
   $tokens['contact']['contact.comm_pref_supporter_url'] = E::ts("Communication Preferences URL");
   $tokens['contact']['contact.comm_pref_supporter_link'] = E::ts("Communication Preferences Link");
-  $tokens['CommunicationPreferences'] = array(
+  $tokens['CommunicationPreferences'] = [
     'CommunicationPreferences.comm_pref_supporter_url' => E::ts("Communication Preferences URL (Bulk Mailing)"),
     'CommunicationPreferences.comm_pref_supporter_link' => E::ts("Communication Preferences Link (Bulk Mailing)"),
-  );
+  ];
 }
 
 /**
  * implementation of hook_civicrm_tokenValues
  */
-function gdpr_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = array(), $context = null) {
+function gdpr_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = [], $context = null) {
   if (!empty($tokens['contact']) OR !empty($tokens['CommunicationPreferences'])) {
     /*
     THIS CHANGE IS ONLY FOR ACTIONSCHEDULE (SEND EMAIL USING SCHEDULE REMINDER)
@@ -541,14 +517,10 @@ function gdpr_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = array(
     the old token.
     IN FUTURE or V3.0, WE CAN REMOVE THIS CHANGE ALONG WITH CONTACT CUSTOM TOKEN ABOVE.
     */
-    $tokenValues = array();
+    $tokenValues = [];
     $cids = isset($cids) ? $cids : [];
     if ($context == 'CRM_Core_BAO_ActionSchedule') {
-      list($tokenValues) = CRM_Utils_Token::getTokenDetails($cids,
-        array(),
-        FALSE,
-        FALSE
-      );
+      list($tokenValues) = CRM_Utils_Token::getTokenDetails($cids, [], FALSE, FALSE);
     }
     foreach ($cids as $cid) {
       if (!empty($tokenValues[$cid])) {
@@ -569,36 +541,36 @@ function gdpr_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = array(
 /**
  * implementation of hook_civicrm_summaryActions
  */
-function gdpr_civicrm_summaryActions( &$actions, $contactID ) {
-  $actions['comm_pref'] = array(
+function gdpr_civicrm_summaryActions(&$actions, $contactID) {
+  $actions['comm_pref'] = [
     'title' => E::ts('Communication Preferences Link'),
     //need a weight parameter here, Contact BAO looking for weight key and returning notice message.
     'weight' => 60,
     'ref' => 'comm_pref',
     'key' => 'comm_pref',
     'href' => CRM_Gdpr_CommunicationsPreferences_Utils::getCommPreferenceURLForContact($contactID, TRUE),
-  );
+  ];
 }
 
 function gdpr_civicrm_permission(&$permissions) {
   $prefix = E::ts('CiviGDPR') . ': ';
-  $permissions += array(
-    'access GDPR' => array(
+  $permissions += [
+    'access GDPR' => [
       $prefix . E::ts('access GDPR'),
       E::ts('View GDPR related information'),
-    ),
-    'forget contact' => array(
+    ],
+    'forget contact' => [
       $prefix . E::ts('forget contact'),
       E::ts('Anonymize contacts'),
-    ),
-    'administer GDPR' => array(
+    ],
+    'administer GDPR' => [
       $prefix . E::ts('administer GDPR'),
       E::ts('Manage GDPR settings'),
-    ),
-  );
+    ],
+  ];
 }
 
-function gdpr_civicrm_searchTasks( $objectName, &$tasks ){
+function gdpr_civicrm_searchTasks($objectName, &$tasks) {
   if($objectName == 'contact'){
     if(CRM_Core_Permission::check('forget contact')) {
       $tasks[] = [
@@ -612,15 +584,15 @@ function gdpr_civicrm_searchTasks( $objectName, &$tasks ){
 /**
  * Implements hook_civicrm_pageRun()
  */
-function gdpr_civicrm_pageRun( &$page ) {
+function gdpr_civicrm_pageRun(&$page) {
   $pageName = $page->getVar('_name');
   if($pageName == 'CRM_Contact_Page_View_Summary') {
     $cid = $page->getVar('_contactId');
     $templatePath = realpath(dirname(__FILE__).'/templates');
     CRM_Core_Region::instance('page-body')->add(
-      array(
+      [
         'template' => "{$templatePath}/CRM/Gdpr/Page/ContactSummary.tpl"
-      )
+      ]
     );
     $accept_activity = CRM_Gdpr_SLA_Utils::getContactLastAcceptance($cid);
     $accept_date = NULL;
@@ -659,11 +631,11 @@ function gdpr_isExtensionEnabled($key) {
  *
  * @return void
  */
-function gdpr_includeShoreditchStylingIfEnabled () {
+function gdpr_includeShoreditchStylingIfEnabled() {
   if (!gdpr_isExtensionEnabled('org.civicrm.shoreditch')) {
     return;
   }
 
   CRM_Core_Resources::singleton()->
-    addStyleFile('uk.co.vedaconsulting.gdpr', 'css/shoreditch-only.min.css', 10);
+  addStyleFile('uk.co.vedaconsulting.gdpr', 'css/shoreditch-only.min.css', 10);
 }

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://vedaconsulting.co.uk</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2021-02-26</releaseDate>
-  <version>3.2</version>
+  <releaseDate>2021-04-09</releaseDate>
+  <version>3.3-dev</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.22</ver>

--- a/templates/CRM/Gdpr/Form/Settings.tpl
+++ b/templates/CRM/Gdpr/Form/Settings.tpl
@@ -13,10 +13,7 @@
 	</ul>
 
 	<div class="crm-submit-buttons">
-		<span class="crm-button crm-i-button">
-		<i class="crm-i fa-check"></i>
-		<input class="crm-form-submit default validate" crm-icon="fa-check" name="fix_custom_data" value="Fix Custom Data" type="button" id="fix_custom_data">
-		</span>
+    <button type="submit" class="button crm-button fix-custom-data" name="fix_custom_data" id="fix_custom_data"><span><i class="crm-i fa-gear" aria-hidden="true"></i> Fix Custom Data</span></button>
 	</div>
 </div>
 {/if}


### PR DESCRIPTION
- Regenerate civix and cleanup
- Use standard helper function to load reCAPTCHA

This makes the extension compatible with PHP7.4, uses a more reliable/simple way to add an item to the navigation menu and uses the standard helper function to load reCAPTCHA on the form.