### PR TITLE
info.xml: fix the documentation URL

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -10,7 +10,7 @@
   </maintainer>
   <urls>
     <url desc="Main Extension Page">https://github.com/veda-consulting/uk.co.vedaconsulting.gdpr</url>
-    <url desc="Documentation">https://gdpr.vedaconsulting.co.uk</url>
+    <url desc="Documentation">https://docs.civicrm.org/gdpr/en/latest/</url>
     <url desc="Support">https://vedaconsulting.co.uk</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>


### PR DESCRIPTION
The site currently referenced (https://gdpr.vedaconsulting.co.uk) is 404.