### PR TITLE
Fix 'Update Comms Prefs' on Civi 5.60+

### DIFF
--- a/CRM/Gdpr/Form/UpdatePreference.php
+++ b/CRM/Gdpr/Form/UpdatePreference.php
@@ -160,6 +160,18 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
   }
 
   /**
+   * Is this being called from an entity reference field.
+   *
+   * E.g clicking on 'New Organization' from the employer field
+   * would create a link with the context = 'dialog' in the url.
+   *
+   * @return bool
+   */
+  public function isEntityReferenceContactCreateMode(): bool {
+    return $this->_context === 'dialog';
+  }
+
+  /**
    * Add the custom fields.
    *
    * @param int $id


### PR DESCRIPTION
Submitting a communication preferences update on Civi 5.60+ results in this error:

```
php Error: Call to undefined method CRM_Gdpr_Form_UpdatePreference::isEntityReferenceContactCreateMode() in CRM_Profile_Form::handleDuplicateChecking() (line 204 of /var/www/mysite/web/sites/all/modules/civicrm/CRM/Profile/Form.php).
```

This extension uses the formRule of `CRM_Profile_Form` but without extending it - so with CRM_Profile_Form calling a new function in its own class, the GDPR extension fails.

I tried to make `CRM_Gdpr_Form_UpdatePreference` extend `CRM_Profile_Form` but that just led to problems, so instead I copied the missing function into this class.