### PR TITLE
PHP 8 fix when contact doesn't exist

### DIFF
--- a/CRM/Gdpr/CommunicationsPreferences/Utils.php
+++ b/CRM/Gdpr/CommunicationsPreferences/Utils.php
@@ -513,7 +513,7 @@ class CRM_Gdpr_CommunicationsPreferences_Utils {
         'id' => $contactId,
       ));
 
-      $existingPreferredMethod = $apiResult['preferred_communication_method'];
+      $existingPreferredMethod = (array) $apiResult['preferred_communication_method'];
       $existingPreferredMethod = array_fill_keys($existingPreferredMethod, 1);
     } catch (Exception $e) {
       CRM_Core_Error::debug_var('updateCommsPrefByFormValues', $e);


### PR DESCRIPTION
When submitting "Update Comms Preferences" on a contact that doesn't currently exist, this error appears:

```
TypeError: array_fill_keys(): Argument #1 ($keys) must be of type array, string given in array_fill_keys() (line 523 of /mysite/web/sites/all/civicrm-custom/extensions/uk.co.vedaconsulting.gdpr/CRM/Gdpr/CommunicationsPreferences/Utils.php)
```

That's because of stricter PHP type checking in PHP8, this is a fix.