### PR TITLE
fix displaying privacy policy on event on PHP8

### DIFF
--- a/CRM/Gdpr/SLA/Entity.php
+++ b/CRM/Gdpr/SLA/Entity.php
@@ -193,13 +193,13 @@ class CRM_Gdpr_SLA_Entity {
 
         $text = $settings['entity_tc_checkbox_text'];
         if (!empty($links['entity'])) {
-          $form->add('checkbox', 'accept_entity_tc', $text, [], TRUE);
+          $form->add('checkbox', 'accept_entity_tc', $text, NULL, TRUE);
         }
       }
     }
 
     if (!empty($links['global'])) {
-      $form->add('checkbox', 'accept_tc', CRM_Gdpr_SLA_Utils::getCheckboxText(), [], TRUE);
+      $form->add('checkbox', 'accept_tc', CRM_Gdpr_SLA_Utils::getCheckboxText(), NULL, TRUE);
     }
     if (!empty($links)) {
       $tc_vars = [


### PR DESCRIPTION
When *Enable terms and Conditions Acceptance* is set to **Yes** on an event when running PHP8, the event registration form crashes.  PHP shows the following error:

```
TypeError: strlen(): Argument #1 ($string) must be of type string, array given in HTML_QuickForm_checkbox->toHtml() (line 138 of /home/jon/local/mysite/web/sites/all/modules/civicrm/packages/HTML/QuickForm/checkbox.php)
```

when using `$form->add()` with `checkbox` as the first argument, the fourth argument becomes the `_text` property - which must be a string, not an array.  Empty arrays and `NULL` are treated the same in PHP7 but in PHP8 we must specify `NULL` or an empty string.